### PR TITLE
README.md: Fix the Melpa link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Getting started
 
 The easiest way to get started is to install the package via [MELPA][melpa]:
 
+ [melpa]: http://melpa.org/
+
 ```elisp
 (package-install 'golden-ratio-scroll-screen)
 ```


### PR DESCRIPTION
My previous PR had a mistake: the melpa link was missing. This corrects that.

Apologies!
